### PR TITLE
fix:process.version is undefined

### DIFF
--- a/lib/default-encoding.js
+++ b/lib/default-encoding.js
@@ -3,7 +3,7 @@ var defaultEncoding
 if (global.process && global.process.browser) {
   defaultEncoding = 'utf-8'
 } else if (global.process && global.process.version) {
-  var pVersionMajor = parseInt(process.version.split('.')[0].slice(1), 10)
+  var pVersionMajor = parseInt(global.process.version.split('.')[0].slice(1), 10)
 
   defaultEncoding = pVersionMajor >= 6 ? 'utf-8' : 'binary'
 } else {


### PR DESCRIPTION
在浏览器环境下
global.process.version 返回 node 的版本号，但是取值的时候使用 process.version，导致为undefined
